### PR TITLE
Better XPath matching for Rimmu-Nation 2 shotguns

### DIFF
--- a/Patches/[RH2] Rimmu-Nation²/[RH2] Rimmu-Nation² - Weapons.xml
+++ b/Patches/[RH2] Rimmu-Nation²/[RH2] Rimmu-Nation² - Weapons.xml
@@ -1,37 +1,41 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>[RH2] Rimmu-Nation² - Weapons</li>
-    </mods>
-    <match Class="PatchOperationSequence">
-      <success>Always</success>
-      <operations>
-        <!-- Defines how many total pellets are launched for the shotgun's projectile -->
-        <!-- You also don't need to change damage amount; the mod will take care of that automatically -->
-        <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]</xpath>
-          <value>
-            <li Class="ProperShotguns.ShotgunExtension">
-              <pelletCount>6</pelletCount>
-            </li>
-          </value>
-        </li>
-        <!-- Changes the shotgun projectile's texture so that it appears to be a single pellet -->
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]/graphicData/texPath</xpath>
-          <value>
-            <texPath>Things/Projectile/Bullet_Small</texPath>
-          </value>
-        </li>
-        <!-- Effectively tells the game that the shotgun should fire buckshots according to its projectile's pelletCount -->
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="RNGUN_AA12_Shotgun" or defName = "RNGun_Remington870MCS_Shotgun" or defName = "RNGun_SPAS12_Shotgun" or defName = "RNGun_Model1897_Shotgun" or defName = "RNGun_IZh43_Shotgun" or defName = "RNGun_BenelliMontefeltro_Shotgun" or defName = "RNGun_Mossberg500_Shotgun" or defName = "RNGun_Saiga12_Shotgun" or defName = "RNGun_USAS12_Shotgun" or defName = "RNGun_SpartanMarine_Shotgun" or defName = "RNGun_M1014_Shotgun" or defName = "RNGun_StoegerCoachGun_Shotgun"]/verbs//li[verbClass="Verb_Shoot" and defaultProjectile="RNBullet_12Gauge_Shotgun"]/verbClass</xpath>
-          <value>
-            <verbClass>ProperShotguns.Verb_ShootShotgun</verbClass>
-          </value>
-        </li>
-      </operations>
-    </match>
-  </Operation>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>[RH2] Rimmu-Nation² - Weapons</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <success>Always</success>
+            <operations>
+                <!-- Defines how many total pellets are launched for the shotgun's projectile -->
+                <!-- You also don't need to change damage amount; the mod will take care of that automatically -->
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]</xpath>
+                    <value>
+                        <li Class="ProperShotguns.ShotgunExtension">
+                            <pelletCount>6</pelletCount>
+                        </li>
+                    </value>
+                </li>
+
+                <!-- Changes the shotgun projectile's texture so that it appears to be a single pellet -->
+                <li Class="PatchOperationReplace">
+                    <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]/graphicData/texPath</xpath>
+                    <value>
+                        <texPath>Things/Projectile/Bullet_Small</texPath>
+                    </value>
+                </li>
+
+                <!-- Effectively tells the game that the shotgun should fire buckshots according to its projectile's pelletCount -->
+                <li Class="PatchOperationReplace">
+                    <xpath>/Defs/ThingDef[starts-with(defName,"RNGun_") and @ParentName="RNMakeableShotgun"]/verbs//li[verbClass="Verb_Shoot" and defaultProjectile="RNBullet_12Gauge_Shotgun"]/verbClass</xpath>
+                    <value>
+                        <verbClass>ProperShotguns.Verb_ShootShotgun</verbClass>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+
 </Patch>

--- a/Patches/[RH2] Rimmu-Nation²/[RH2] Rimmu-Nation² - Weapons.xml
+++ b/Patches/[RH2] Rimmu-Nation²/[RH2] Rimmu-Nation² - Weapons.xml
@@ -1,41 +1,37 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>[RH2] Rimmu-Nation² - Weapons</li>
-        </mods>
-        <match Class="PatchOperationSequence">
-            <success>Always</success>
-            <operations>
-                <!-- Defines how many total pellets are launched for the shotgun's projectile -->
-                <!-- You also don't need to change damage amount; the mod will take care of that automatically -->
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]</xpath>
-                    <value>
-                        <li Class="ProperShotguns.ShotgunExtension">
-                            <pelletCount>6</pelletCount>
-                        </li>
-                    </value>
-                </li>
-
-                <!-- Changes the shotgun projectile's texture so that it appears to be a single pellet -->
-                <li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]/graphicData/texPath</xpath>
-                    <value>
-                        <texPath>Things/Projectile/Bullet_Small</texPath>
-                    </value>
-                </li>
-
-                <!-- Effectively tells the game that the shotgun should fire buckshots according to its projectile's pelletCount -->
-                <li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[starts-with(defName,"RNGun_") and @ParentName="RNMakeableShotgun"]/verbs//li[verbClass="Verb_Shoot" and defaultProjectile="RNBullet_12Gauge_Shotgun"]/verbClass</xpath>
-                    <value>
-                        <verbClass>ProperShotguns.Verb_ShootShotgun</verbClass>
-                    </value>
-                </li>
-            </operations>
-        </match>
-    </Operation>
-
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>[RH2] Rimmu-Nation² - Weapons</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+        <!-- Defines how many total pellets are launched for the shotgun's projectile -->
+        <!-- You also don't need to change damage amount; the mod will take care of that automatically -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]</xpath>
+          <value>
+            <li Class="ProperShotguns.ShotgunExtension">
+              <pelletCount>6</pelletCount>
+            </li>
+          </value>
+        </li>
+        <!-- Changes the shotgun projectile's texture so that it appears to be a single pellet -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="RNBullet_12Gauge_Shotgun"]/graphicData/texPath</xpath>
+          <value>
+            <texPath>Things/Projectile/Bullet_Small</texPath>
+          </value>
+        </li>
+        <!-- Effectively tells the game that the shotgun should fire buckshots according to its projectile's pelletCount -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[starts-with(defName,"RNGun_") and @ParentName="RNMakeableShotgun"]/verbs//li[verbClass="Verb_Shoot" and defaultProjectile="RNBullet_12Gauge_Shotgun"]/verbClass</xpath>
+          <value>
+            <verbClass>ProperShotguns.Verb_ShootShotgun</verbClass>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 </Patch>


### PR DESCRIPTION
I noticed that the Pancor Jackhammer in Rimmu-Nation 2 isn't covered by the current patch, and while I was looking, I wrote an XPath that matches Rimmu-Nation 2 shotguns by their parent defs instead of exact defNames. Some quick testing shows that it matches all current shotguns in the mod, and should also catch any future additions as long as the mod author keeps using the same parent and naming convention.

Edit: This is two commits instead of one because I was doing my editing based on the file published to Steam Workshop instead of the one from the repo, so it looked like there were more changes than there actually were. The second commit is just cleaning it up so you can actually see what's changed from the master branch.