### PR TITLE
Initial support for GTek's Arsenal

### DIFF
--- a/Patches/GTek Arsenal/GTek Arsenal - Shotguns.xml
+++ b/Patches/GTek Arsenal/GTek Arsenal - Shotguns.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>GTek's Arsenal 2.0 - Ultimate Survival and Colony Defense</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+        <!-- Defines how many total pellets are launched for the shotgun's projectile -->
+        <!-- You also don't need to change damage amount; the mod will take care of that automatically -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/ThingDef[defName="HIDBullet_410Bore"]</xpath>
+          <value>
+            <li Class="ProperShotguns.ShotgunExtension">
+              <pelletCount>4</pelletCount>
+            </li>
+          </value>
+        </li>
+        <!-- Changes the shotgun projectile's texture so that it appears to be a single pellet -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="HIDBullet_410Bore"]/graphicData/texPath</xpath>
+          <value>
+            <texPath>Things/Projectile/Bullet_Small</texPath>
+          </value>
+        </li>
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/ThingDef[defName="HIDBullet_10Gauge"]</xpath>
+          <value>
+            <li Class="ProperShotguns.ShotgunExtension">
+              <pelletCount>8</pelletCount>
+            </li>
+          </value>
+        </li>
+        <!-- Changes the shotgun projectile's texture so that it appears to be a single pellet -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="HIDBullet_10Gauge"]/graphicData/texPath</xpath>
+          <value>
+            <texPath>Things/Projectile/Bullet_Small</texPath>
+          </value>
+        </li>
+        <!-- Effectively tells the game that the shotgun should fire buckshots according to its projectile's pelletCount -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[starts-with(defName, "HIDGun_")][contains(thingCategories/li, "Shotguns") and not(weaponClasses/li="LongShots")]/verbs//li[verbClass="Verb_Shoot"][defaultProjectile="HIDBullet_410Bore" or defaultProjectile="HIDBullet_10Gauge" or defaultProjectile="Bullet_Shotgun"]/verbClass</xpath>
+          <value>
+            <verbClass>ProperShotguns.Verb_ShootShotgun</verbClass>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>


### PR DESCRIPTION
Threw together a quick patch for GTek's Arsenal, based on the existing Rimmu-Nation 2 patch. It works nicely from my testing so far, affecting all of the shotguns in the mod that I've tested while not modifying anything that explicitly uses slugs.